### PR TITLE
MGET fails on non-existent keys

### DIFF
--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -105,6 +105,8 @@ class MultiBulkReply:
                 return result
             elif isinstance(result, bytes):
                 return self.protocol.decode_to_native(result)
+            elif result is None:
+                return result
             else:
                 raise AssertionError('Invalid type: %r' % type(result))
 

--- a/tests.py
+++ b/tests.py
@@ -156,10 +156,10 @@ class RedisProtocolTest(unittest.TestCase):
         # mget
         yield from protocol.set(u'my_key', u'a')
         yield from protocol.set(u'my_key2', u'b')
-        result = yield from protocol.mget([ u'my_key', u'my_key2' ])
+        result = yield from protocol.mget([ u'my_key', u'my_key2', u'not_exists'])
         self.assertIsInstance(result, ListReply)
         result = yield from result.get_as_list()
-        self.assertEqual(result, [u'a', u'b'])
+        self.assertEqual(result, [u'a', u'b', None])
 
     @redis_test
     def test_strlen(self, transport, protocol):


### PR DESCRIPTION
Small bug fix.

BTW, why MGET command needs two `yield from` statements to get result?
I mean

``` python
list_reply = yield from conn.mget(...)
mget_result = yield from list_reply.get_as_list()
```

May be it should be united in `mget` coroutine?

Sergey
