### PR TITLE
Fix bad handling of connection timeout

### DIFF
--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -480,7 +480,6 @@ class RedisProtocol(asyncio.Protocol):
 
     def data_received(self, data):
         """ Process data received from Redis server.  """
-        logger.info("Feeding data: |%r|" % data)
         self._reader.feed_data(data)
 
     def _encode_int(self, value:int) -> bytes:


### PR DESCRIPTION
If redis is set to timeout connections, you get a KeyError as the protocol can't handle the empty byte response from the read.  Instead, it should raise a ConnectionLostError.

As you can see, it took me a while to figure out the problem and easy fix, so feel free to patch it in manually :) 
