### PR TITLE
fix NoTypeCheckingTest

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1543,14 +1543,24 @@ class NoTypeCheckingTest(unittest.TestCase):
         # Override protocol, disabling type checking.
         class NoTypeCheckingProtocol(RedisProtocol):
             enable_typechecking = False
-
+            def __init__(self, *args, encoder=BytesEncoder(),
+                         enable_typechecking=False, **kwargs):
+                super().__init__(*args, encoder=encoder,
+                                 enable_typechecking=enable_typechecking,
+                                 **kwargs)
         self.loop = asyncio.get_event_loop()
-        transport, protocol = yield from loop.create_connection(
-                    NoTypeCheckingProtocol, 'localhost', PORT)
 
-        # Setting values should still work.
-        result = yield from protocol.set(b'key', b'value')
-        self.assertEqual(result, StatusReply('OK'))
+        @asyncio.coroutine
+        def test():
+
+            transport, protocol = yield from self.loop.create_connection(
+                        NoTypeCheckingProtocol, 'localhost', PORT)
+
+            # Setting values should still work.
+            result = yield from protocol.set(b'key', b'value')
+            self.assertEqual(result, StatusReply('OK'))
+
+        self.loop.run_until_complete(test())
 
 
 class RedisConnectionTest(unittest.TestCase):


### PR DESCRIPTION
This test returns generator and no reactor loop is initialized.
And some default args for protocol should be overriden to make test pass.
