### PR TITLE
Transaction failure should not leave the protocol in a faulty state

### DIFF
--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -2197,6 +2197,9 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
 
         if multi_bulk_reply is None:
             # We get None when a transaction failed.
+            self._transaction_response_queue = deque()
+            self._in_transaction = False
+            self._transaction = None
             raise TransactionError('Transaction failed.')
         else:
             assert isinstance(multi_bulk_reply, MultiBulkReply)


### PR DESCRIPTION
Previously, if a transaction failed, the protocol thought it was inside a transaction while the server knew it was not. This state mismatch rendered the protocol instance unusable.

This patch just fixes the state mismatch, so the protocol and the server agree after a transaction failure.
