### PR TITLE
Add an option to avoid blocking in `{Connection,Pool}.create`

### DIFF
--- a/asyncio_redis/connection.py
+++ b/asyncio_redis/connection.py
@@ -20,8 +20,8 @@ class Connection:
     """
     @classmethod
     @asyncio.coroutine
-    def create(cls, host='localhost', port=6379, *, password=None, db=0,
-               encoder=None, auto_reconnect=True, loop=None, protocol_class=RedisProtocol):
+    def create(cls, host='localhost', port=6379, *, password=None, db=0, encoder=None,
+               auto_reconnect=True, loop=None, block=True, protocol_class=RedisProtocol):
         """
         :param host: Address, either host or unix domain socket path
         :type host: str
@@ -36,6 +36,8 @@ class Connection:
         :param auto_reconnect: Enable auto reconnect
         :type auto_reconnect: bool
         :param loop: (optional) asyncio event loop.
+        :param block: (optional) Do not return until the connection is ready (True by default)
+        :type block: bool
         :type protocol_class: :class:`~asyncio_redis.RedisProtocol`
         :param protocol_class: (optional) redis protocol implementation
         """
@@ -61,7 +63,10 @@ class Connection:
                         connection_lost_callback=connection_lost, loop=connection._loop)
 
         # Connect
-        yield from connection._reconnect()
+        if block:
+            yield from connection._reconnect()
+        else:
+            asyncio.async(connection._reconnect(), loop=connection._loop)
 
         return connection
 

--- a/asyncio_redis/pool.py
+++ b/asyncio_redis/pool.py
@@ -25,7 +25,7 @@ class Pool:
     @classmethod
     @asyncio.coroutine
     def create(cls, host='localhost', port=6379, *, password=None, db=0,
-               encoder=None, poolsize=1, auto_reconnect=True, loop=None,
+               encoder=None, poolsize=1, auto_reconnect=True, loop=None, block=True,
                protocol_class=RedisProtocol):
         """
         Create a new connection pool instance.
@@ -45,12 +45,15 @@ class Pool:
         :param auto_reconnect: Enable auto reconnect
         :type auto_reconnect: bool
         :param loop: (optional) asyncio event loop.
+        :param block: (optional) Do not return until all connections are ready (True by default)
+        :type block: bool
         :type protocol_class: :class:`~asyncio_redis.RedisProtocol`
         :param protocol_class: (optional) redis protocol implementation
         """
         self = cls()
         self._host = host
         self._port = port
+        self._loop = loop
         self._poolsize = poolsize
 
         # Create connections
@@ -59,7 +62,7 @@ class Pool:
         for i in range(poolsize):
             connection = yield from Connection.create(host=host, port=port,
                             password=password, db=db, encoder=encoder,
-                            auto_reconnect=auto_reconnect, loop=loop,
+                            auto_reconnect=auto_reconnect, loop=loop, block=block,
                             protocol_class=protocol_class)
             self._connections.append(connection)
 

--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -785,6 +785,9 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
         self._transaction = None
         self._transaction_response_queue = None # Transaction answer queue
 
+        # Pipelined calls
+        self._pipelined_calls = set() # Set of all the pipelined calls.
+
         self._line_received_handlers = {
             b'+': self._handle_status_reply,
             b'-': self._handle_error_reply,
@@ -797,9 +800,6 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
         self.transport = transport
         self._is_connected = True
         logger.log(logging.INFO, 'Redis connection made')
-
-        # Pipelined calls
-        self._pipelined_calls = set() # Set of all the pipelined calls.
 
         # Start parsing reader stream.
         self._reader = StreamReader(loop=self._loop)


### PR DESCRIPTION
This is useful, for example, if you expect that both the application and the Redis server may go offline and then back online at any time. By creating a `Pool` with `block=False`, you'll no longer have to worry about `create` blocking until Redis goes online (which may never happen); instead, all connections will simply be in a disconnected state, and the pool will behave in the same way as if Redis went offline *after* the application connected successfully (i.e. raise `NoAvailableConnectionsInPoolError` on any attempt to invoke a command).