### PR TITLE
Add a RedisProtocol.watch() method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ Contributors
 - David Creswick <dcrewi AT gyrae.net>
 - Denya <denya.msk AT gmail.com>
 - Don Brown <mrdon AT twdata.org>
+- Martin Richard <martius AT martiusweb.net>
 - Oleg Baranovskiy <ramovsky AT ya.ru>
 - Piotr Husiatyński <phusiatynski AT gmail.com>
 - Saúl Ibarra Corretgé <saghul AT gmail.com>

--- a/tests.py
+++ b/tests.py
@@ -1761,6 +1761,28 @@ class RedisProtocolTest(TestCase):
     @redis_test
     def test_watch_1(self, transport, protocol):
         """
+        Test a transaction using watch.
+        (Retrieve the watched value then use it inside the transaction.)
+        """
+        yield from protocol.set(u'key', u'val')
+
+        # Test
+        yield from protocol.watch([u'key'])
+        value = yield from protocol.get(u'key')
+
+        t = yield from protocol.multi()
+
+        yield from t.set(u'key', value + u'ue')
+
+        yield from t.exec()
+
+        # Check
+        result = yield from protocol.get(u'key')
+        self.assertEqual(result, u'value')
+
+    @redis_test
+    def test_multi_watch_1(self, transport, protocol):
+        """
         Test a transaction, using watch
         (Test using the watched key inside the transaction.)
         """
@@ -1785,7 +1807,7 @@ class RedisProtocolTest(TestCase):
         self.assertEqual(result, u'my_value')
 
     @redis_test
-    def test_watch_2(self, transport, protocol):
+    def test_multi_watch_2(self, transport, protocol):
         """
         Test using the watched key outside the transaction.
         (the transaction should fail in this case.)


### PR DESCRIPTION
Following the issue #62,

I propose a pull request with a patch adding RedisProtocol.watch() method. RedisProtocol.multi() has been updated in order to use the new method.

I added a test case addressing the one described in the issue, while the two existing tests already cover other common cases for watch(). Other cases can be tested (such as cases with unwatch()) but I'm not sure it's in the scope of this PR.

Cheers