### PR TITLE
Added LIMIT support for ZRangeByScore

### DIFF
--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -1581,19 +1581,23 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
     @_query_command
     def zrangebyscore(self, key:NativeType,
                 min:ZScoreBoundary=ZScoreBoundary.MIN_VALUE,
-                max:ZScoreBoundary=ZScoreBoundary.MAX_VALUE) -> ZRangeReply:
+                max:ZScoreBoundary=ZScoreBoundary.MAX_VALUE,
+                offset:int=0, limit:int=-1) -> ZRangeReply:
         """ Return a range of members in a sorted set, by score """
         return self._query(b'zrangebyscore', self.encode_from_native(key),
                     self._encode_zscore_boundary(min), self._encode_zscore_boundary(max),
+                    b'limit', self._encode_int(offset), self._encode_int(limit),
                     b'withscores')
 
     @_query_command
     def zrevrangebyscore(self, key:NativeType,
                 max:ZScoreBoundary=ZScoreBoundary.MAX_VALUE,
-                min:ZScoreBoundary=ZScoreBoundary.MIN_VALUE) -> ZRangeReply:
+                min:ZScoreBoundary=ZScoreBoundary.MIN_VALUE,
+                offset:int=0, limit:int=-1) -> ZRangeReply:
         """ Return a range of members in a sorted set, by score, with scores ordered from high to low """
         return self._query(b'zrevrangebyscore', self.encode_from_native(key),
                     self._encode_zscore_boundary(max), self._encode_zscore_boundary(min),
+                    b'limit', self._encode_int(offset), self._encode_int(limit),
                     b'withscores')
 
     @_query_command

--- a/tests.py
+++ b/tests.py
@@ -1131,6 +1131,14 @@ class RedisProtocolTest(TestCase):
         self.assertEqual((yield from result.asdict()),
                 { 'key': 4.0, 'key2': 5.0 })
 
+        result = yield from protocol.zrangebyscore('myzset', limit=1)
+        self.assertEqual((yield from result.asdict()),
+                { 'key': 4.0 })
+
+        result = yield from protocol.zrangebyscore('myzset', offset=1)
+        self.assertEqual((yield from result.asdict()),
+                { 'key2': 5.0, 'key3': 5.5 })
+
         # Test zrevrangebyscore (identical to zrangebyscore, unless we call aslist)
         result = yield from protocol.zrevrangebyscore('myzset')
         self.assertIsInstance(result, DictReply)
@@ -1150,6 +1158,14 @@ class RedisProtocolTest(TestCase):
                 { 'key': 4.0, 'key2': 5.0, 'key3': 5.5 })
         result = yield from protocol.zrevrangebyscore('myzset',
                         max=ZScoreBoundary(5.5, exclude_boundary=True))
+        self.assertEqual((yield from result.asdict()),
+                { 'key': 4.0, 'key2': 5.0 })
+
+        result = yield from protocol.zrevrangebyscore('myzset', limit=1)
+        self.assertEqual((yield from result.asdict()),
+                { 'key3': 5.5 })
+
+        result = yield from protocol.zrevrangebyscore('myzset', offset=1)
         self.assertEqual((yield from result.asdict()),
                 { 'key': 4.0, 'key2': 5.0 })
 


### PR DESCRIPTION
ID → range lookups like [geoip lookups](http://redis4you.com/articles.php?id=018&name=GeoIP+in+Redis) require this, so it would be nice to have the LIMIT parameter supported.

Adding `LIMIT 0 -1` to the command does not change the result, so using those two values as default is fine.