### PR TITLE
Added missing @asyncio.coroutine

### DIFF
--- a/asyncio_redis/connection.py
+++ b/asyncio_redis/connection.py
@@ -82,6 +82,7 @@ class Connection:
         """ When a connection failed. Increase the interval."""
         self._retry_interval = min(60, 1.5 * self._retry_interval)
 
+    @asyncio.coroutine
     def _reconnect(self):
         """
         Set up Redis connection.

--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -611,6 +611,7 @@ class CommandCreator:
         # directly on the protocol, outside of transactions or from the
         # transaction object.
         @wraps(method)
+        @asyncio.coroutine
         def wrapper(protocol_self, *a, **kw):
             # When calling from a transaction
             if protocol_self.in_transaction:
@@ -688,6 +689,7 @@ _SMALL_INTS = list(str(i).encode('ascii') for i in range(1000))
 
 # List of all command methods.
 _all_commands = []
+
 
 class _command:
     """ Mark method as command (to be passed through CommandCreator for the
@@ -1981,6 +1983,7 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
     # LUA scripting
 
     @_command
+    @asyncio.coroutine
     def register_script(self, script:str) -> 'Script':
         """
         Register a LUA script.
@@ -2006,6 +2009,7 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
         return self._query(b'script', b'flush')
 
     @_query_command
+    @asyncio.coroutine
     def script_kill(self) -> StatusReply:
         """
         Kill the script currently in execution.  This raises
@@ -2021,6 +2025,7 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
                 raise
 
     @_query_command
+    @asyncio.coroutine
     def evalsha(self, sha:str,
                         keys:(ListOf(NativeType), NoneType)=None,
                         args:(ListOf(NativeType), NoneType)=None) -> EvalScriptReply:


### PR DESCRIPTION
Python 3.5 introduces the couple of keywords async/await.

They are compatible with the "yield from" syntax and generator coroutines as
long as they are decorated with @asyncio.coroutine. Some of them where missing,
so code like:

    async def coro(redis_client):
        await redis_client.watch(key)

failed with the error:

    TypeError: object generator can't be used in 'await' expression

It may be a good idea to write a special test file for python3.5 to be sure everything is running well when using async/await.