### PR TITLE
fix warning for deprecated async()

### DIFF
--- a/asyncio_redis/connection.py
+++ b/asyncio_redis/connection.py
@@ -54,7 +54,7 @@ class Connection:
         # Create protocol instance
         def connection_lost():
             if connection._auto_reconnect and not connection._closing:
-                asyncio.async(connection._reconnect(), loop=connection._loop)
+                asyncio.ensure_future(connection._reconnect(), loop=connection._loop)
 
         # Create protocol instance
         connection.protocol = protocol_class(password=password, db=db, encoder=encoder,

--- a/asyncio_redis/protocol.py
+++ b/asyncio_redis/protocol.py
@@ -634,7 +634,7 @@ class CommandCreator:
                         typecheck_return(protocol_self, result)
                         future2.set_result(result)
 
-                    future.add_done_callback(lambda f: asyncio.async(done(f.result()), loop=protocol_self._loop))
+                    future.add_done_callback(lambda f: asyncio.ensure_future(done(f.result()), loop=protocol_self._loop))
 
                     return future2
 
@@ -806,7 +806,7 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
         # Start parsing reader stream.
         self._reader = StreamReader(loop=self._loop)
         self._reader.set_transport(transport)
-        self._reader_f = asyncio.async(self._reader_coroutine(), loop=self._loop)
+        self._reader_f = asyncio.ensure_future(self._reader_coroutine(), loop=self._loop)
 
         @asyncio.coroutine
         def initialize():
@@ -825,7 +825,7 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
                 if self._pubsub_patterns:
                     yield from self._psubscribe(self._subscription, list(self._pubsub_patterns))
 
-        asyncio.async(initialize(), loop=self._loop)
+        asyncio.ensure_future(initialize(), loop=self._loop)
 
     def data_received(self, data):
         """ Process data received from Redis server.  """
@@ -978,7 +978,7 @@ class RedisProtocol(asyncio.Protocol, metaclass=_RedisProtocolMeta):
 
         # Return the empty queue immediately as an answer.
         if self._in_pubsub:
-            asyncio.async(self._handle_pubsub_multibulk_reply(reply), loop=self._loop)
+            asyncio.ensure_future(self._handle_pubsub_multibulk_reply(reply), loop=self._loop)
         else:
             cb(reply)
 

--- a/asyncio_redis/replies.py
+++ b/asyncio_redis/replies.py
@@ -62,7 +62,7 @@ class DictReply:
 
         for _ in range(self._result.count // 2):
             read_future = self._result._read(count=2)
-            yield asyncio.async(getter(read_future), loop=self._result._loop)
+            yield asyncio.ensure_future(getter(read_future), loop=self._result._loop)
 
     @asyncio.coroutine
     def asdict(self):


### PR DESCRIPTION
Im getting this warning message in python 3.5.0:
 DeprecationWarning: asyncio.async() function is deprecated, use ensure_future()   DeprecationWarning)