### PR TITLE
Adding parser for InfoReply and ClientListReply

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ Contributors
 - Aymeric Augustin <aymeric.augustin AT m4x.org>
 - Daniel Arbuckle <djarb AT highenergymagic.org>
 - David Creswick <dcrewi AT gyrae.net>
+- David Testé <soonum AT gnu.org>
 - Denya <denya.msk AT gmail.com>
 - Don Brown <mrdon AT twdata.org>
 - Martin Richard <martius AT martiusweb.net>

--- a/asyncio_redis/replies.py
+++ b/asyncio_redis/replies.py
@@ -196,13 +196,44 @@ class ConfigPairReply:
 class InfoReply:
     """ :func:`~asyncio_redis.RedisProtocol.info` reply. """
     def __init__(self, data):
-        self._data = data # TODO: implement parser logic
+        self._data = self._parse(data)
+
+    @property
+    def data(self):
+        """ Received info """
+        return self._data
+
+    def _parse(self, data):
+        info = {}
+        for line in data.split():
+            if not line.startswith(b"#"):
+                key, _, value = line.partition(b":")
+                info[key] = value
+
+        return info
 
 
 class ClientListReply:
     """ :func:`~asyncio_redis.RedisProtocol.client_list` reply. """
     def __init__(self, data):
-        self._data = data # TODO: implement parser logic
+        self._data = self._parse(data)
+
+    @property
+    def data(self):
+        """ Received client list """
+        return self._data
+
+    def _parse(self, data):
+        client_list = []
+        for line in data.splitlines():
+            pairs = line.split(b" ")
+            client_info = {}
+            print(pairs)
+            for pair in pairs:
+                client_info = dict(pair.split(b"=") for pair in pairs)
+            client_list.append(client_info)
+
+        return client_list
 
 
 class PubSubReply:


### PR DESCRIPTION
Hi there,

I've a need for handling data contained in InfoReply object. Since the parser is on the TODO list, I wish to implement it. I also took the time to implement a parser for ClientListReply object.

These are naive parsers, all of the value are displayed as `bytes` string (no attempts of type conversion). The data structures are pretty straight forward:

- InfoReply: return a `dict` containing all the key/value pair found in the reply. The sections, the lines starting with `b"# "`, are not used as keys here. I don't know if we should do something like that `info = {section_name1: {section_key1, section_value2}, section_name2: {...}, }` instead.
- ClientListReply: return a `list` of `dict`, each element of the list representing a client

I make this Pull Request to discuss the implementation of these parsers, thus if you have any suggestion about it (since this implementation will do the job for my project), I'll be pleased to modifiy it.
Naturally, the tests will be written once the design has been validated.

Cheers, 